### PR TITLE
fix(auth): harden security and unify response schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
           NODE_ENV: test
           JWT_SECRET: test-jwt-secret-for-testing-only
           RUN_MIGRATIONS_ON_STARTUP: 'false'
+          RATE_LIMIT_MAX: '10000'
+          RATE_LIMIT_AUTH_MAX: '10000'
 
   audit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ src/
     rateLimit.ts
   utils/
     appError.ts
+    database.ts
     httpStatusCodes.ts
     response.ts
     schemaErrorFormatter.ts
@@ -105,6 +106,12 @@ Docs em `http://localhost:3000/docs`
 - `BCRYPT_ROUNDS` é configurável via env (default `10`). Aumentar em produção conforme capacidade do hardware.
 - `RUN_MIGRATIONS_ON_STARTUP` deve permanecer `false` no container da app em produção. Migrations devem rodar em job dedicado antes do deploy.
 - Emails são normalizados para lowercase na criação e busca de usuários.
+- Login usa comparação timing-safe: tempo de resposta é constante independentemente de o email existir ou não, prevenindo enumeração de usuários por timing attack.
+- Registro é race-condition safe: usa insert direto com captura de violação de unique constraint (409 Conflict), eliminando TOCTOU.
+- Rate limit global aplicado a todas as rotas. Endpoints de auth (`/login`, `/register`) possuem limites mais restritivos configurados por rota.
+- Content Security Policy (CSP) do Helmet é habilitada em produção (quando `ENABLE_DOCS=false`). Em desenvolvimento, CSP é desabilitada para compatibilidade com Swagger UI.
+- O seed (`db:seed`) possui guard contra execução em produção.
+- O endpoint `/me` consulta o banco para retornar dados atualizados do usuário, garantindo que tokens de usuários deletados sejam rejeitados.
 
 ## Variáveis de ambiente
 

--- a/llms.txt
+++ b/llms.txt
@@ -45,10 +45,14 @@ Para novas features:
 ## Security
 
 - JWT via `@fastify/jwt` com validação de `iss` e `aud`.
-- Rate limit global e mais restritivo em endpoints de auth.
-- Helmet e CORS registrados na construção da app.
+- Rate limit global aplicado a todas as rotas. Endpoints de auth possuem limites mais restritivos configurados por rota.
+- Helmet com CSP habilitada em produção (desabilitada em dev para Swagger UI). CORS registrado na construção da app.
 - `TRUST_PROXY` configurável via env para ambientes atrás de reverse proxy (afeta `request.ip` e rate limit).
 - Emails normalizados para lowercase para evitar duplicatas case-sensitive.
+- Login com comparação timing-safe contra enumeração de usuários.
+- Registro race-condition safe via insert-first + catch unique constraint (409 Conflict).
+- Endpoint `/me` consulta o banco para dados atualizados; rejeita tokens de usuários deletados.
+- Seed protegido contra execução em produção.
 
 ## Testing
 

--- a/postman/real-world-fastify.postman_collection.json
+++ b/postman/real-world-fastify.postman_collection.json
@@ -103,8 +103,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Status code is 201 or 400 (duplicate)', function () {",
-                  "  pm.expect([201, 400]).to.include(pm.response.code);",
+                  "pm.test('Status code is 201 or 409 (duplicate)', function () {",
+                  "  pm.expect([201, 409]).to.include(pm.response.code);",
                   "});",
                   "",
                   "var jsonData = pm.response.json();",
@@ -206,10 +206,13 @@
                   "});",
                   "",
                   "var jsonData = pm.response.json();",
-                  "pm.test('/me returns authenticated user payload', function () {",
+                  "pm.test('/me returns authenticated user profile', function () {",
                   "  pm.expect(jsonData.success).to.eql(true);",
                   "  pm.expect(jsonData.data.email).to.eql(pm.collectionVariables.get('email'));",
-                  "  pm.expect(jsonData.data.userId).to.be.a('number');",
+                  "  pm.expect(jsonData.data.id).to.be.a('number');",
+                  "  pm.expect(jsonData.data.name).to.be.a('string');",
+                  "  pm.expect(jsonData.data.createdAt).to.be.a('string');",
+                  "  pm.expect(jsonData.data.updatedAt).to.be.a('string');",
                   "});"
                 ]
               }

--- a/src/app.ts
+++ b/src/app.ts
@@ -93,7 +93,7 @@ export function buildApp() {
 
   server.register(helmet, {
     global: true,
-    contentSecurityPolicy: false,
+    ...(config.enableDocs && { contentSecurityPolicy: false }),
   });
 
   server.register(cors, {

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -6,6 +6,10 @@ import bcrypt from "bcryptjs";
 dotenv.config();
 
 async function seed() {
+  if (process.env["NODE_ENV"] === "production") {
+    throw new Error("Seed must not run in production");
+  }
+
   const databaseUrl = process.env["DATABASE_URL"];
 
   if (!databaseUrl) {
@@ -14,7 +18,7 @@ async function seed() {
 
   const db = createDbConnection(databaseUrl);
 
-  const hashedPassword = await bcrypt.hash("Password123", 10);
+  const hashedPassword = await bcrypt.hash("S3ed!Dev#2025x", 10);
 
   await db.insert(users).values([
     {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,8 +2,8 @@ import { FastifyReply, FastifyRequest } from "fastify";
 import { LoginInputType, RegisterInputType } from "./auth.schema";
 import { validateUser, generateJwt, registerUser } from "./auth.service";
 import { HttpStatus } from "../../utils/httpStatusCodes";
-import { error, success } from "../../utils/response";
-import { sanitizeUser } from "../users/user.service";
+import { error, success, unauthorized } from "../../utils/response";
+import { sanitizeUser, findById } from "../users/user.service";
 
 export async function registerHandler(
   request: FastifyRequest<{ Body: RegisterInputType }>,
@@ -30,6 +30,10 @@ export async function loginHandler(
 }
 
 export async function meHandler(request: FastifyRequest, reply: FastifyReply) {
-  const { userId, email } = request.user;
-  return success(reply, { userId, email });
+  const { userId } = request.user;
+  const user = await findById(request.server, userId);
+  if (!user) {
+    return unauthorized(reply, "User no longer exists");
+  }
+  return success(reply, sanitizeUser(user));
 }

--- a/src/modules/auth/auth.route.ts
+++ b/src/modules/auth/auth.route.ts
@@ -8,6 +8,7 @@ import {
   RegisterInput,
   RegisterResponse,
 } from "./auth.schema";
+import { config } from "../../config/env";
 
 export function registerAuthRoutes(
   server: FastifyInstance,
@@ -19,6 +20,12 @@ export function registerAuthRoutes(
       fastifyTypebox.post(
         "/register",
         {
+          config: {
+            rateLimit: {
+              max: config.rateLimitAuthMax,
+              timeWindow: config.rateLimitAuthWindow,
+            },
+          },
           schema: {
             body: RegisterInput,
             response: {
@@ -34,6 +41,12 @@ export function registerAuthRoutes(
       fastifyTypebox.post(
         "/login",
         {
+          config: {
+            rateLimit: {
+              max: config.rateLimitAuthMax,
+              timeWindow: config.rateLimitAuthWindow,
+            },
+          },
           schema: {
             body: LoginInput,
             response: {
@@ -54,7 +67,7 @@ export function registerAuthRoutes(
             response: {
               200: MeResponse,
             },
-            description: "Get authenticated user payload",
+            description: "Get authenticated user profile",
             tags: ["authentication"],
             security: [{ bearerAuth: [] }],
           },

--- a/src/modules/auth/auth.schema.ts
+++ b/src/modules/auth/auth.schema.ts
@@ -16,15 +16,6 @@ export const RegisterInput = Type.Object({
 
 export type RegisterInputType = Static<typeof RegisterInput>;
 
-export const RegisterResponse = Type.Object({
-  success: Type.Boolean(),
-  data: Type.Object({
-    id: Type.Number(),
-    email: Type.String(),
-    name: Type.String(),
-  }),
-});
-
 export const LoginInput = Type.Object({
   email: Type.String({ format: "email", minLength: 5, maxLength: 255 }),
   password: Type.String({ minLength: 8, maxLength: 100 }),
@@ -32,22 +23,28 @@ export const LoginInput = Type.Object({
 
 export type LoginInputType = Static<typeof LoginInput>;
 
+export const UserResponse = Type.Object({
+  id: Type.Number(),
+  email: Type.String(),
+  name: Type.String(),
+  createdAt: Type.String({ format: "date-time" }),
+  updatedAt: Type.String({ format: "date-time" }),
+});
+
+export const RegisterResponse = Type.Object({
+  success: Type.Boolean(),
+  data: UserResponse,
+});
+
 export const LoginResponse = Type.Object({
   success: Type.Boolean(),
   data: Type.Object({
     token: Type.String(),
-    user: Type.Object({
-      id: Type.Number(),
-      email: Type.String(),
-      name: Type.String(),
-    }),
+    user: UserResponse,
   }),
 });
 
 export const MeResponse = Type.Object({
   success: Type.Boolean(),
-  data: Type.Object({
-    userId: Type.Number(),
-    email: Type.String(),
-  }),
+  data: UserResponse,
 });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -5,23 +5,23 @@ import { findByEmail, create, comparePassword } from "../users/user.service";
 import { User } from "../../db/schema";
 import { AppError } from "../../utils/appError";
 import { HttpStatus } from "../../utils/httpStatusCodes";
+import { isUniqueViolation } from "../../utils/database";
+
+const DUMMY_HASH =
+  "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy";
 
 export async function registerUser(
   server: FastifyInstance,
   input: Static<typeof RegisterInput>,
 ): Promise<User> {
-  const { email } = input;
-
-  const existingUser = await findByEmail(server, email);
-
-  if (existingUser) {
-    throw new AppError(
-      "User with this email already exists",
-      HttpStatus.BAD_REQUEST,
-    );
+  try {
+    return await create(server, input);
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new AppError("Email is already in use", HttpStatus.CONFLICT);
+    }
+    throw err;
   }
-
-  return create(server, input);
 }
 
 export async function validateUser(
@@ -31,7 +31,10 @@ export async function validateUser(
 ): Promise<User | null> {
   const user = await findByEmail(server, email);
 
-  if (!user) return null;
+  if (!user) {
+    await comparePassword(password, DUMMY_HASH);
+    return null;
+  }
 
   const isPasswordValid = await comparePassword(password, user.password);
 

--- a/src/plugins/rateLimit.ts
+++ b/src/plugins/rateLimit.ts
@@ -1,36 +1,15 @@
-import {
-  FastifyInstance,
-  FastifyPluginAsync,
-  FastifyRequest,
-  RouteOptions,
-} from "fastify";
+import { FastifyInstance, FastifyPluginAsync, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 import rateLimit from "@fastify/rate-limit";
 import { config } from "../config/env";
 
 const rateLimitPlugin: FastifyPluginAsync = async (server: FastifyInstance) => {
   await server.register(rateLimit, {
-    global: false,
+    global: true,
     max: config.rateLimitMax,
     timeWindow: config.rateLimitWindow,
     cache: 10000,
     keyGenerator: (request: FastifyRequest) => request.ip,
-  });
-
-  server.addHook("onRoute", (routeOptions: RouteOptions) => {
-    if (
-      routeOptions.url &&
-      (routeOptions.url.includes("/api/auth/login") ||
-        routeOptions.url.includes("/api/auth/register"))
-    ) {
-      routeOptions.config = {
-        ...(routeOptions.config || {}),
-        rateLimit: {
-          max: config.rateLimitAuthMax,
-          timeWindow: config.rateLimitAuthWindow,
-        },
-      } as NonNullable<RouteOptions["config"]>;
-    }
   });
 };
 

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,0 +1,23 @@
+function hasCode23505(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "code" in value &&
+    (value as { code: string }).code === "23505"
+  );
+}
+
+export function isUniqueViolation(error: unknown): boolean {
+  if (hasCode23505(error)) return true;
+
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "cause" in error &&
+    hasCode23505((error as { cause: unknown }).cause)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/utils/httpStatusCodes.ts
+++ b/src/utils/httpStatusCodes.ts
@@ -5,5 +5,6 @@ export enum HttpStatus {
   UNAUTHORIZED = 401,
   FORBIDDEN = 403,
   NOT_FOUND = 404,
+  CONFLICT = 409,
   INTERNAL_ERROR = 500,
 }

--- a/test/auth/auth.test.ts
+++ b/test/auth/auth.test.ts
@@ -50,6 +50,24 @@ describe("Auth Module", () => {
       expect(body.data.id).toBeDefined();
     });
 
+    test("should include timestamps in register response", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/auth/register",
+        payload: {
+          email: "timestamps@example.com",
+          password: "Password123",
+          name: "Timestamps User",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.payload);
+      expect(body.data.createdAt).toBeDefined();
+      expect(body.data.updatedAt).toBeDefined();
+      expect(new Date(body.data.createdAt).getTime()).not.toBeNaN();
+    });
+
     test("should fail to register user with duplicate email", async () => {
       await app.inject({
         method: "POST",
@@ -71,10 +89,10 @@ describe("Auth Module", () => {
         },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(409);
       const body = JSON.parse(response.payload);
       expect(body.success).toBe(false);
-      expect(body.message).toContain("already exists");
+      expect(body.message).toContain("already in use");
     });
 
     test("should fail to register user with duplicate email in different case", async () => {
@@ -98,10 +116,10 @@ describe("Auth Module", () => {
         },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(409);
       const body = JSON.parse(response.payload);
       expect(body.success).toBe(false);
-      expect(body.message).toContain("already exists");
+      expect(body.message).toContain("already in use");
     });
 
     test("should login with email in different case than registered", async () => {
@@ -297,7 +315,43 @@ describe("Auth Module", () => {
       const body = JSON.parse(response.payload);
       expect(body.success).toBe(true);
       expect(body.data).toBeDefined();
+      expect(body.data.id).toBeDefined();
       expect(body.data.email).toBe("protected@example.com");
+      expect(body.data.name).toBe("Protected User");
+      expect(body.data.createdAt).toBeDefined();
+      expect(body.data.updatedAt).toBeDefined();
+      expect(body.data.password).toBeUndefined();
+    });
+
+    test("should return 401 when user was deleted after login", async () => {
+      await app.db.delete(users);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/auth/me",
+        headers: {
+          authorization: `Bearer ${validToken}`,
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.payload);
+      expect(body.success).toBe(false);
+      expect(body.message).toContain("no longer exists");
+    });
+
+    test("should return fresh data from database", async () => {
+      const meResponse = await app.inject({
+        method: "GET",
+        url: "/api/auth/me",
+        headers: {
+          authorization: `Bearer ${validToken}`,
+        },
+      });
+
+      const body = JSON.parse(meResponse.payload);
+      expect(body.data.email).toBe("protected@example.com");
+      expect(body.data.name).toBe("Protected User");
     });
 
     test("should reject access without token", async () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -7,3 +7,5 @@ process.env["DATABASE_URL"] =
   process.env["DATABASE_URL"] ||
   "postgresql://postgres:postgres@localhost:5432/fastify_db";
 process.env["RUN_MIGRATIONS_ON_STARTUP"] = "false";
+process.env["RATE_LIMIT_MAX"] = "10000";
+process.env["RATE_LIMIT_AUTH_MAX"] = "10000";


### PR DESCRIPTION
## Summary

- **Timing-safe login**: bcrypt compare contra dummy hash quando usuário não existe, prevenindo enumeração de usuários via timing attack
- **Race-condition-safe register**: insert-first com catch de unique constraint (Postgres 23505), retorna `409 Conflict` em vez de `400`
- **Rate limit global**: todas as rotas agora têm rate limit, rotas de auth possuem limites mais restritivos via config per-route (removido hook com string matching frágil)
- **CSP condicional**: Helmet CSP habilitado em produção, desabilitado apenas quando Swagger UI está ativo
- **Seed hardening**: guard contra execução em produção + senha padrão mais forte
- **`/me` consulta o banco**: busca dados frescos via `findById`, retorna `401` se o usuário foi deletado após emissão do token
- **Schema unificado**: `UserResponse` compartilhado com timestamps (`createdAt`, `updatedAt`) usado em register, login e /me
- **Novo utilitário**: `src/utils/database.ts` com `isUniqueViolation` (compatível com wrapping do Drizzle)