### PR TITLE
chore(docker): auto-build DATABASE_URL and add npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Docs em `http://localhost:3000/docs`
 - Em produção, `ENABLE_DOCS` é desabilitado por padrão.
 - `TRUST_PROXY` deve ser `true` quando a aplicação rodar atrás de reverse proxy (Nginx, Cloudflare, ALB). Afeta `request.ip` e rate limit.
 - `BCRYPT_ROUNDS` é configurável via env (default `10`). Aumentar em produção conforme capacidade do hardware.
-- `RUN_MIGRATIONS_ON_STARTUP` deve permanecer `false` no container da app em produção. Migrations devem rodar em job dedicado antes do deploy.
+- `RUN_MIGRATIONS_ON_STARTUP` é `true` por padrão no Docker Compose para facilitar setup local. Em produção, desabilite e rode migrations em job dedicado antes do deploy.
 - Emails são normalizados para lowercase na criação e busca de usuários.
 - Login usa comparação timing-safe: tempo de resposta é constante independentemente de o email existir ou não, prevenindo enumeração de usuários por timing attack.
 - Registro é race-condition safe: usa insert direto com captura de violação de unique constraint (409 Conflict), eliminando TOCTOU.
@@ -156,15 +156,17 @@ Docs em `http://localhost:3000/docs`
 
 ## Docker
 
-As variáveis `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB` são obrigatórias para qualquer perfil do Docker Compose.
+O `docker-compose.yml` constrói a `DATABASE_URL` automaticamente a partir de `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB`, usando o hostname interno do serviço (`db`). Não é necessário definir `DATABASE_URL` manualmente para Docker.
 
-Banco apenas:
+Migrations rodam automaticamente no startup (`RUN_MIGRATIONS_ON_STARTUP=true` por padrão no compose). Em produção, desabilite e rode em job dedicado antes do deploy.
+
+Banco apenas (para desenvolvimento local com `pnpm dev`):
 
 ```bash
 ./deploy.sh --db-only
 ```
 
-Aplicação + banco:
+Aplicação completa (app + banco, ambiente similar a produção):
 
 ```bash
 ./deploy.sh --build
@@ -176,16 +178,15 @@ Parar tudo:
 ./deploy.sh --down
 ```
 
-Para subir aplicação + banco em perfil `app`, exporte variáveis obrigatórias antes:
+Para customizar credenciais ou habilitar Swagger UI, ajuste as variáveis no `.env`:
 
-```bash
-export POSTGRES_USER=app_user
-export POSTGRES_PASSWORD=strong_db_password
-export POSTGRES_DB=app_db
-export DATABASE_URL=postgresql://app_user:strong_db_password@db:5432/app_db
-export JWT_SECRET=replace_with_32_plus_characters_secret
-export CORS_ORIGIN=https://api.example.com,https://admin.example.com
-./deploy.sh --build
+```env
+POSTGRES_USER=app_user
+POSTGRES_PASSWORD=strong_db_password
+POSTGRES_DB=app_db
+JWT_SECRET=replace_with_32_plus_characters_secret
+CORS_ORIGIN=https://api.example.com,https://admin.example.com
+ENABLE_DOCS=true
 ```
 
 Para executar migrations em produção, rode um job dedicado:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -48,22 +48,22 @@ Nesse caso, confirme que o banco está acessível e que as migrations foram apli
 
 ## Erro ao subir app com Docker
 
-Se aparecer erro de variável obrigatória ausente em `docker compose`, exporte:
+O `docker-compose.yml` constrói a `DATABASE_URL` automaticamente a partir de `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB`. Não é necessário definir `DATABASE_URL` manualmente.
 
-```bash
-export POSTGRES_USER=app_user
-export POSTGRES_PASSWORD=strong_db_password
-export POSTGRES_DB=app_db
-export DATABASE_URL=postgresql://app_user:strong_db_password@db:5432/app_db
-export JWT_SECRET=replace_with_32_plus_characters_secret
-export CORS_ORIGIN=https://api.example.com
+Se aparecer erro de variável obrigatória ausente, garanta que o `.env` contém:
+
+```env
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=fastify_db
+JWT_SECRET=replace_with_32_plus_characters_secret
 ```
 
 ## Migrations em produção
 
-Por padrão, o container da aplicação não executa migrations no startup (`RUN_MIGRATIONS_ON_STARTUP=false`).
+Por padrão no Docker Compose, migrations rodam automaticamente no startup (`RUN_MIGRATIONS_ON_STARTUP=true`). Isso facilita o setup local.
 
-É possível habilitar via `RUN_MIGRATIONS_ON_STARTUP=true`, mas o recomendado é rodar migrations em job dedicado antes do deploy:
+Em produção, desabilite (`RUN_MIGRATIONS_ON_STARTUP=false`) e rode migrations em job dedicado antes do deploy:
 
 ```bash
 pnpm db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,15 +12,15 @@ services:
       - NODE_ENV=production
       - PORT=3000
       - HOST=0.0.0.0
-      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db:5432/${POSTGRES_DB:?POSTGRES_DB is required}
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required}
-      - JWT_EXPIRES_IN=1d
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-1d}
       - JWT_ISSUER=${JWT_ISSUER:-real-world-fastify}
       - JWT_AUDIENCE=${JWT_AUDIENCE:-real-world-fastify-users}
-      - CORS_ORIGIN=${CORS_ORIGIN:?CORS_ORIGIN is required}
+      - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3000}
       - ENABLE_DOCS=${ENABLE_DOCS:-false}
-      - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-false}
-      - LOG_LEVEL=info
+      - RUN_MIGRATIONS_ON_STARTUP=${RUN_MIGRATIONS_ON_STARTUP:-true}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
     depends_on:
       db:
         condition: service_healthy

--- a/llms.txt
+++ b/llms.txt
@@ -54,6 +54,12 @@ Para novas features:
 - Endpoint `/me` consulta o banco para dados atualizados; rejeita tokens de usuários deletados.
 - Seed protegido contra execução em produção.
 
+## Docker
+
+- `docker-compose.yml` constrói `DATABASE_URL` automaticamente a partir de `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB` com hostname interno `db`.
+- Migrations rodam automaticamente no startup por padrão (`RUN_MIGRATIONS_ON_STARTUP=true`). Desabilitar em produção.
+- `./deploy.sh --build` sobe app + banco. `./deploy.sh --db-only` sobe apenas o banco para desenvolvimento local.
+
 ## Testing
 
 - Jest com testes em `test/`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "tsx scripts/run-tests.ts",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "docker:up": "docker compose --profile app up -d --build",
+    "docker:down": "docker compose --profile app down",
+    "docker:db": "docker compose --profile db up -d"
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",


### PR DESCRIPTION
## Summary

- `docker-compose.yml` agora constrói `DATABASE_URL` automaticamente a partir de `POSTGRES_USER`, `POSTGRES_PASSWORD` e `POSTGRES_DB` com hostname interno `db`, eliminando configuração manual
- `RUN_MIGRATIONS_ON_STARTUP` default `true` no compose para setup local funcionar sem passos extras
- Adicionados scripts `docker:up`, `docker:down` e `docker:db` no `package.json` (cross-platform, sem depender de bash)
- Documentação atualizada (README, TROUBLESHOOTING, llms.txt)

## Test plan

- `pnpm docker:db` sobe apenas o Postgres
- `pnpm docker:up` builda e sobe app + banco, migrations rodam automaticamente
- `pnpm docker:down` para todos os containers